### PR TITLE
optionally get the configuration from the context

### DIFF
--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -9,9 +9,12 @@ from importlib import import_module
 register = template.Library()
 
 
-@register.inclusion_tag('admin_shortcuts/base.html')
-def admin_shortcuts():
-    admin_shortcuts = copy.deepcopy(getattr(settings, 'ADMIN_SHORTCUTS', None))
+@register.inclusion_tag('admin_shortcuts/base.html', takes_context=True)
+def admin_shortcuts(context):
+    if 'ADMIN_SHORTCUTS' in context:
+        admin_shortcuts = copy.deepcopy(context['ADMIN_SHORTCUTS'])
+    else:
+        admin_shortcuts = copy.deepcopy(getattr(settings, 'ADMIN_SHORTCUTS', None))
     admin_shortcuts_settings = copy.deepcopy(getattr(settings, 'ADMIN_SHORTCUTS_SETTINGS', None))
 
     if not admin_shortcuts:


### PR DESCRIPTION
this allows (in an unfortunately quite crude way) to set per-adminsite configuration:

```
from django.contrib.admin import AdminSite

class SimpleAdmin(AdminSite):
    # todo: add templates here (see attrs on base class)
    ADMIN_SHORTCUTS = [{
        'shortcuts': [{
            'url': '/',
            'open_new_window': True,
        },],
    },]

    def index(self, request, extra_context=None):
        extra_context = extra_context or {}
        extra_context['ADMIN_SHORTCUTS'] = self.ADMIN_SHORTCUTS
        return super(SimpleAdmin, self).index(request, extra_context)

supplier_admin = SimpleAdmin()
```
