### PR TITLE
let counter functions optionally take the request object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,8 @@ Where ...
     * optional ``url`` is a direct link that will override ``url_name``
     * optional ``url_extra`` is extra stuff to be attached at the end of the url (like GET data for pre-filtering admin views)
     * optional ``title`` is the title of the shortcut
-    * optional ``count`` and ``count_new`` are paths to a function inside your project that returns something interesting (like a count of all products or a count of all pending orders)
+    * optional ``count`` and ``count_new`` are paths to a function inside your project that returns something interesting (like a count of all products or a count of all pending orders).
+      The function can optionally take one argument, ``request``, which is the current Django ``HttpRequest`` object.
     * optional ``open_new_window`` sets whether the link should open in a new window (default is False)
     * optional ``class`` is the CSS class to be added to the anchor element (if you don't specify one, magical ponies will do it for you)
 


### PR DESCRIPTION
this is useful when the count depends on the logged in user or other data depending on the request
