### PR TITLE
Permissions - shortcut is visible only if the user has the right to access named url.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ How do I use it?
 
 Where ...
 
-    * ``url_name`` is a name that will be resolved using django's reverse url method (see https://docs.djangoproject.com/en/1.4/ref/contrib/admin/#reversing-admin-urls)
+    * ``url_name`` is a name that will be resolved using django's reverse url method (see https://docs.djangoproject.com/en/1.4/ref/contrib/admin/#reversing-admin-urls), shortcut will appear only if the user is permitted to access named url
     * optional ``app_name`` is the name of the admin app that will be used for URL reversal. You can safely ignore this if you have only one admin site in your ``urls.py``
     * optional ``url`` is a direct link that will override ``url_name``
     * optional ``url_extra`` is extra stuff to be attached at the end of the url (like GET data for pre-filtering admin views)

--- a/admin_shortcuts/templates/admin_shortcuts/base.html
+++ b/admin_shortcuts/templates/admin_shortcuts/base.html
@@ -3,12 +3,16 @@
 {% if admin_shortcuts %}
 	<ul class="shortcuts">
 	{% for group in admin_shortcuts %}
-		{% if group.title %}<h2>{{ group.title }}</h2>{% endif %}
-		<ul>
-		{% for shortcut in group.shortcuts %}
-			<li>{% include 'admin_shortcuts/shortcut.html' %}</li>
-		{% endfor %}
-		</ul>
+		{% if group.permitted %}
+			{% if group.title %}<h2>{{ group.title }}</h2>{% endif %}
+			<ul>
+			{% for shortcut in group.shortcuts %}
+				{% if shortcut.permitted %}
+					<li>{% include 'admin_shortcuts/shortcut.html' %}</li>
+				{% endif %}
+			{% endfor %}
+			</ul>
+		{% endif %}
 	{% endfor %}
 	</ul>
 {% endif %}


### PR DESCRIPTION
This is alternative approach to issue #1 that, unlike solution in pull request #12 for better or for worse, does not require user input to hide shortcuts and groups that are not accessible by current user.