### PR TITLE
Correctly translate group and shortcut titles

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 
 * Ales Kocjancic
 * Benjamin Wohlwend
+* Venelin Stoykov

--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -4,7 +4,7 @@ from django import template
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext, ugettext_lazy as _
 from django.utils.importlib import import_module
 
 register = template.Library()
@@ -24,6 +24,10 @@ def admin_shortcuts(context):
     for group in admin_shortcuts:
         if not group.get('shortcuts'):
             raise ImproperlyConfigured('settings.ADMIN_SHORTCUTS is improperly configured.')
+
+        if group.get('title'):
+            group['title'] = ugettext(group['title'])
+
         enabled_shortcuts = []
         for shortcut in group.get('shortcuts'):
             if shortcut.get('has_perms'):
@@ -52,6 +56,9 @@ def admin_shortcuts(context):
 
             if shortcut.get('count_new'):
                 shortcut['count_new'] = eval_func(shortcut['count_new'], request)
+
+            if shortcut.get('title'):
+                shortcut['title'] = ugettext(shortcut['title'])
 
             enabled_shortcuts.append(shortcut)
 


### PR DESCRIPTION
In the documentation titles are shown like translated strings but in settings you can't use `ugettext`. If you use `_ = lambda x: x` in settings and still want to use translatable titles they need to be translated when shown.