### PR TITLE
Added importlb dependency. django.utils.importlib removed since 1.9.

### DIFF
--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext
 try:
     from django.utils.module_loading import import_module
 except ImportError:
-    from django.utils.importlib import import_module
+    from importlib import import_module
 
 register = template.Library()
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=[
         'Django>=1.2',
+        'importlib>=1.0.3',
     ],
 )
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/internals/deprecation/#deprecation-removed-in-1-9