### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -9,9 +9,12 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 
 try:
-    from django.utils.module_loading import import_module
+    from importlib import import_module
 except ImportError:
-    from django.utils.importlib import import_module
+    try:
+        from django.utils.module_loading import import_module
+    except ImportError:
+        from django.utils.importlib import import_module
 
 register = template.Library()
 


### PR DESCRIPTION
django-admin-shortcuts raises an _ImportError_ in Django 1.9 because `django.utils.importlib` has been [deprecated](https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9) in 1.9. We are supposed to use `importlib` from the standard library. I left the other imports in there as a fallback because `importlib` is only available in Python 2.7 and above. But according to `setup.py` Python 2.6 should also be supported.