### PR TITLE
Fix issue when using ManifestStaticFilesStorage as STATICFILES_STORAGE

### DIFF
--- a/admin_shortcuts/templates/admin_shortcuts/style.css
+++ b/admin_shortcuts/templates/admin_shortcuts/style.css
@@ -41,5 +41,5 @@
 
 {% block icons %}
 /* icons */
-{% for class in classes %}.admin_shortcuts .shortcuts li a.{{ class }} { background-image: url('{% static "admin_shortcuts" %}/{{ class }}.png'); }{% endfor %}
+{% for class in classes %}.admin_shortcuts .shortcuts li a.{{ class }} { background-image: url('{% static "admin_shortcuts/" %}{{ class }}.png'); }{% endfor %}
 {% endblock %}


### PR DESCRIPTION
Django will look for a key "admin_shortcuts" in the manifest created by collectstatic.
This will never be there and raise an error.

Moving the slash "/" makes sure it's seen as directory and handled correctly.