### PR TITLE
feat: Add python3.11 compatibility by using inspect.signature

### DIFF
--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -123,7 +123,10 @@ def eval_func(func_path, request):
         module = import_module(module_str)
         result = getattr(module, func_str)
         if callable(result):
-            args, varargs, keywords, defaults = inspect.getargspec(result)
+            try:
+                args = inspect.signature(result).parameters
+            except AttributeError:  # Python version < 3.3
+                args = inspect.getargspec(result)[0]
             if 'request' in args:
                 result = result(request)
             else:


### PR DESCRIPTION
- Uses inspect.signature for compatibility with Python3.11 (which does not have getargspec function).
- inspect.signature will be used from Python3.3 onwards, keeping the same behaviour getargspec had.
- getargspec will still be used for Python < 3.3