### PR TITLE
admin_shortcuts_tags.py - fix for url_extra option

### DIFF
--- a/admin_shortcuts/templatetags/admin_shortcuts_tags.py
+++ b/admin_shortcuts/templatetags/admin_shortcuts_tags.py
@@ -87,7 +87,9 @@ def admin_shortcuts(context):
                 else:
                     shortcut['url'] = reverse(url_name, current_app=current_app)
 
-                shortcut['url'] += shortcut.get('url_extra', '')
+            if shortcut.get('url_extra'):
+                shortcut['url_extra'] = eval_func(shortcut['url_extra'], request)
+                shortcut['url'] += shortcut['url_extra']
 
             if not shortcut.get('icon'):
                 class_text = force_str(shortcut.get('url_name', shortcut.get('url', '')))


### PR DESCRIPTION
1. 'url_extra' could only ever take effect if the 'url_name' tag was specified rather than the 'url' tag, due I believe to incorrect indentation in the line in 'admin_shortcuts_tags.py' where the 'url_extra' tag is appended to the 'url'.

2. 'url_extra' could only be specified as a string to be appended, whereas one might  expect to be able to specify a function, as in 'count' or 'count_new', which permit either a string or a function. 

This change fixes both issues